### PR TITLE
Explicitly set Speed Control anchors to 'grey'.

### DIFF
--- a/tampermonkey-script.js
+++ b/tampermonkey-script.js
@@ -23,6 +23,7 @@
 
   function appendSpeedControl(div, speed) {
     var speedAnchor = document.createElement('a')
+    speedAnchor.style.color = 'grey'
     speedAnchor.style.display = 'block'
     speedAnchor.style.cursor = 'pointer'
     speedAnchor.onclick = function() {


### PR DESCRIPTION
Speed controls are not visible because the background and the font are both white. I suggest to explicitly set font color to 'grey'.